### PR TITLE
Fix CI pytest settings module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,5 +33,5 @@ jobs:
 
       - name: Run pytest
         env:
-          DJANGO_SETTINGS_MODULE: config.settings.test
-        run: pytest --ds=config.settings.test --cov
+          DJANGO_SETTINGS_MODULE: config.settings.base
+        run: pytest --ds=config.settings.base --cov


### PR DESCRIPTION
## Summary
- update the CI workflow to use the existing Django settings module when running pytest

## Testing
- not run (configuration change only)

------
https://chatgpt.com/codex/tasks/task_e_68ecc8b9f2308320aecab843e892dcfa