### PR TITLE
Fix nextjs version detection on vercel deploy

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,14 @@
+{
+  "version": 2,
+  "builds": [
+    {
+      "src": "frontend/package.json",
+      "use": "@vercel/static-build",
+      "config": { "distDir": "dist" }
+    }
+  ],
+  "routes": [
+    { "handle": "filesystem" },
+    { "src": "/(.*)", "dest": "/index.html" }
+  ]
+}


### PR DESCRIPTION
## شرح تغییر
فایل `vercel.json` برای پیکربندی صحیح دیپلوی Vercel اضافه شد. این تغییر مشکل "No Next.js version detected" را حل می‌کند، زیرا پروژه در `frontend` یک برنامه Vite React است و نه Next.js. `vercel.json` مسیر بیلد را به `frontend` با استفاده از `@vercel/static-build` و روتینگ SPA را تنظیم می‌کند.

## نوع تغییر
- [x] رفع اشکال
- [ ] ویژگی جدید
- [ ] تغییر ناسازگار
- [ ] به‌روزرسانی مستندات

## راهکار تست
- [x] تست‌ها به صورت محلی با موفقیت اجرا می‌شوند.
- [ ] تست‌های جدید اضافه شده‌اند.
- [ ] پوشش تست حفظ شده یا بهبود یافته است.

## چک‌لیست
- [x] کد از راهنمای استایل پروژه پیروی می‌کند.
- [x] کد توسط خودم بازبینی شده است.
- [ ] کدهای پیچیده کامنت‌گذاری شده‌اند.
- [ ] مستندات مرتبط به‌روز شده‌اند.
- [x] هیچ هشدار جدیدی وجود ندارد.

---
<a href="https://cursor.com/background-agent?bcId=bc-a6e0aa51-5bda-447f-8fe1-7b628359a8c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a6e0aa51-5bda-447f-8fe1-7b628359a8c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

